### PR TITLE
fix mobile tokenization with 2-digit year

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -224,7 +224,8 @@ module Heartland {
       card.exp = expElement;
 
       if (card.exp) {
-        var cardExpSplit = (<HTMLInputElement>card.exp).value.split('/');
+        var formatter = new Heartland.Formatter.Expiration();
+        var cardExpSplit = formatter.format((<HTMLInputElement>card.exp).value, true).split('/');
         card.expMonth = cardExpSplit[0];
         card.expYear = cardExpSplit[1];
         card.exp = undefined;


### PR DESCRIPTION
haven't found a better replacement for `blur` event that doesn't seem to be firing, causing the last format to run