### PR TITLE
correct firefox tab issue

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -273,4 +273,33 @@ export class Events {
       type: 'pan'
     });
   }
+
+  /**
+   * Ensures frame's input field is active instead of frame
+   *
+   * @param {HPS} HPS instance
+   * @param {Object} event data
+   */
+  public static ensureFrameFocusToInput(hps: HPS, event: any) {
+    if (event.type !== "blur") {
+      return;
+    }
+
+    const order = hps.options.tabOrder;
+    const name = event.source;
+
+    if (!name) {
+      return;
+    }
+
+    const targetIndex = order.indexOf(name);
+
+    if (targetIndex === -1) {
+      return;
+    }
+
+    if (targetIndex + 1 <= order.length && order[targetIndex + 1]) {
+      hps.setFocus(order[targetIndex + 1]);
+    }
+  }
 }

--- a/src/Frames.ts
+++ b/src/Frames.ts
@@ -177,9 +177,14 @@ export class Frames {
           );
           break;
         case 'fieldEvent':
+          if (hps.options.tabOrder) {
+            Events.ensureFrameFocusToInput(hps, data.event);
+          }
+
           if (!options.onEvent) {
             break;
           }
+
           options.onEvent(data.event);
           break;
         case 'error':

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -33,4 +33,5 @@ export interface Options {
     orderNumber?: string;
     jwt?: string;
   };
+  tabOrder?: string[];
 }

--- a/src/vars/defaults.ts
+++ b/src/vars/defaults.ts
@@ -22,6 +22,7 @@ export const defaults: Options = {
   pinBlock: '',
   publicKey: '',
   success: null,
+  tabOrder: ['cardNumber', 'cardExpiration', 'cardCvv', 'submit'],
   targetType: '',
   tokenType: 'supt',
   track: '',


### PR DESCRIPTION
IFrame was receiving focus before input, so manual intervention is necessary. It's either this sort of approach or using `setInterval` to periodically check the document's active element (not preferred).

integrator can opt-out by setting `options.tabOrder` to `null`.